### PR TITLE
Add desktop and clients information

### DIFF
--- a/mycroft.py
+++ b/mycroft.py
@@ -3,6 +3,7 @@ import re
 
 
 class Mycroft(BotPlugin):
+
     """
     ask questions about mycroft and interact with a mycroft instance
     """
@@ -55,32 +56,34 @@ class Mycroft(BotPlugin):
                  "here, https://github.com/MycroftAI/enclosure-picroft/wiki" \
                  "/Getting-Started-Guide."
         return output
-    
+
     @botcmd
     def install_plasmoid(self, mess, args):
-        """A command that gives information about installing the KDE Plasmoid"""
-        output = "The install guide for the KDE plasmoid project can be found " \
-                 "here, https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
-                 "If you are running a Debian/Ubuntu or Fedora based distribution" \
-                 "You can find the installation scripts here, https://github.com/MycroftAI/installers"
+        """A command that gives information about installing KDE Plasmoid"""
+        output = "Follow the plasmoid install guide" \
+                 "at, https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
+                 "If you are running an Ubuntu or Fedora based distribution" \
+                 "You can find the installation scripts" \
+                 "here, https://github.com/MycroftAI/installers"
         return output
-    
+
     @botcmd
     def install_qtapp(self, mess, args):
-        """A command that gives information about installing the QT Application"""
-        output = "The appimage for the qt standalone application project can be found " \
-                 "here, https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"
+        """A command that gives info about installing the QTApplication"""
+        output = "Appimage for the standalone Qtapplication is available at" \
+                 "https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"
         return output
-    
+
     @botcmd
     def install_qtapp(self, mess, args):
-        """A command that gives troublehooting information about the KDE Plasmoid"""
+        """A command that gives troublehooting info for the KDE Plasmoid"""
         output = "Steps to troubleshoot your plasmoid install" \
                  "* Check if mycroft-core is installed correctly" \
                  "* Open plasmoid settings and check your mycroft path" \
-                 "* Run plasmashell in debug mode and check for error messages" \
+                 "* Run plasmashell in debug mode report error messages" \
                  "* Submit your issue/bug report on the #desktop channel, or" \
-                 "* Create a bug report here, https://bugs.kde.org/describecomponents.cgi?product=plasma-mycroft"
+                 "* Create a bug report at https://bugs.kde.org/" \
+                 "/describecomponents.cgi?product=plasma-mycroft"
         return output
 
     @botcmd
@@ -110,13 +113,13 @@ class Mycroft(BotPlugin):
         output = "The current list of mycroft skills can be found here, " \
                  "https://github.com/MycroftAI/mycroft-skills"
         return output
-    
+
     @botcmd
     def desktop_clients(self, mess, args):
         """A command that list currently available desktop clients"""
         output = "The current list of mycroft desktop clients, " \
-                 "KDE Plasma Desktop: https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
-                 "Other Desktop Environments: https://github.com/AIIX/Mycroft-AI-QtApplication/releases"
+                 "KDE: http://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
+                 "Others: https://github.com/AIIX/Mycroft-AI-QtApplication"
         return output
 
     @botcmd

--- a/mycroft.py
+++ b/mycroft.py
@@ -55,6 +55,33 @@ class Mycroft(BotPlugin):
                  "here, https://github.com/MycroftAI/enclosure-picroft/wiki" \
                  "/Getting-Started-Guide."
         return output
+    
+    @botcmd
+    def install_plasmoid(self, mess, args):
+        """A command that gives information about installing the KDE Plasmoid"""
+        output = "The install guide for the KDE plasmoid project can be found " \
+                 "here, https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
+                 "If you are running a Debian/Ubuntu or Fedora based distribution" \
+                 "You can find the installation scripts here, https://github.com/MycroftAI/installers"
+        return output
+    
+    @botcmd
+    def install_qtapp(self, mess, args):
+        """A command that gives information about installing the QT Application"""
+        output = "The appimage for the qt standalone application project can be found " \
+                 "here, https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"
+        return output
+    
+    @botcmd
+    def install_qtapp(self, mess, args):
+        """A command that gives troublehooting information about the KDE Plasmoid"""
+        output = "Steps to troubleshoot your plasmoid install" \
+                 "* Check if mycroft-core is installed correctly" \
+                 "* Open plasmoid settings and check your mycroft path" \
+                 "* Run plasmashell in debug mode and check for error messages" \
+                 "* Submit your issue/bug report on the #desktop channel, or" \
+                 "* Create a bug report here, https://bugs.kde.org/describecomponents.cgi?product=plasma-mycroft"
+        return output
 
     @botcmd
     def picroft_docs(self, mess, args):
@@ -82,6 +109,14 @@ class Mycroft(BotPlugin):
         """A command that links you the skills repo"""
         output = "The current list of mycroft skills can be found here, " \
                  "https://github.com/MycroftAI/mycroft-skills"
+        return output
+    
+    @botcmd
+    def desktop_clients(self, mess, args):
+        """A command that list currently available desktop clients"""
+        output = "The current list of mycroft desktop clients, " \
+                 "KDE Plasma Desktop: https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
+                 "Other Desktop Environments: https://github.com/AIIX/Mycroft-AI-QtApplication/releases"
         return output
 
     @botcmd

--- a/mycroft.py
+++ b/mycroft.py
@@ -68,14 +68,14 @@ class Mycroft(BotPlugin):
         return output
 
     @botcmd
-    def install_qtapp(self, mess, args):
+    def install_qtapplication(self, mess, args):
         """A command that gives info about installing the QTApplication"""
         output = "Appimage for the standalone Qtapplication is available at" \
                  "https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"
         return output
 
     @botcmd
-    def install_qtapp(self, mess, args):
+    def troubleshoot_plasmoid(self, mess, args):
         """A command that gives troublehooting info for the KDE Plasmoid"""
         output = "Steps to troubleshoot your plasmoid install" \
                  "* Check if mycroft-core is installed correctly" \

--- a/mycroft.py
+++ b/mycroft.py
@@ -78,11 +78,11 @@ class Mycroft(BotPlugin):
     def troubleshoot_plasmoid(self, mess, args):
         """A command that gives troublehooting info for the KDE Plasmoid"""
         output = "Steps to troubleshoot your plasmoid install" \
-                 "* Check if mycroft-core is installed correctly" \
-                 "* Open plasmoid settings and check your mycroft path" \
-                 "* Run plasmashell in debug mode report error messages" \
-                 "* Submit your issue/bug report on the #desktop channel, or" \
-                 "* Create a bug report at https://bugs.kde.org/" \
+                 "1: Check if mycroft is installed correctly" \
+                 "2: Open plasmoid settings and check your mycroft path" \
+                 "3: Run plasmashell in debug mode report error messages" \
+                 "4: Submit your issue's on the #desktop channel, or" \
+                 "5: Create a bug report at https://bugs.kde.org" \
                  "/describecomponents.cgi?product=plasma-mycroft"
         return output
 

--- a/test_mycroft.py
+++ b/test_mycroft.py
@@ -54,8 +54,8 @@ class TestMycroftBot(object):
                  "here, https://github.com/MycroftAI/installers"
         assert output in testbot.pop_message()
 
-    def test_install_qtapp(self, testbot):
-        testbot.push_message('!install_qt_application')
+    def test_install_qtapplication(self, testbot):
+        testbot.push_message('!install_qtapplication')
         output = "Appimage for the standalone Qtapplication is available at" \
                  "https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"
         assert output in testbot.pop_message()

--- a/test_mycroft.py
+++ b/test_mycroft.py
@@ -63,11 +63,11 @@ class TestMycroftBot(object):
     def test_troubleshoot_plasmoid(self, testbot):
         testbot.push_message('!troubleshoot_plasmoid')
         output = "Steps to troubleshoot your plasmoid install" \
-                 "* Check if mycroft-core is installed correctly" \
-                 "* Open plasmoid settings and check your mycroft path" \
-                 "* Run plasmashell in debug mode report error messages" \
-                 "* Submit your issue/bug report on the #desktop channel, or" \
-                 "* Create a bug report at https://bugs.kde.org/" \
+                 "1: Check if mycroft is installed correctly" \
+                 "2: Open plasmoid settings and check your mycroft path" \
+                 "3: Run plasmashell in debug mode report error messages" \
+                 "4: Submit your issue's on the #desktop channel, or" \
+                 "5: Create a bug report at https://bugs.kde.org" \
                  "/describecomponents.cgi?product=plasma-mycroft"
         assert output in testbot.pop_message()
 

--- a/test_mycroft.py
+++ b/test_mycroft.py
@@ -11,7 +11,6 @@ class TestMycroftBot(object):
         assert 'The mycroft documentation can be found at ' \
                'https://docs.mycroft.ai' in testbot.pop_message()
 
-
     def test_install_mycroft(self, testbot):
         testbot.push_message('!install_mycroft')
         assert "The information for installing mycroft " \
@@ -45,31 +44,33 @@ class TestMycroftBot(object):
                  "here, https://github.com/MycroftAI/enclosure-picroft/wiki" \
                  "/Getting-Started-Guide."
         assert output in testbot.pop_message()
-        
+
     def test_install_plasmoid(self, testbot):
         testbot.push_message('!install_kde_plasmoid')
-        output = "The install guide for the KDE plasmoid project can be found " \
-                 "here, https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
-                 "If you are running a Debian/Ubuntu or Fedora based distribution" \
-                 "You can find the installation scripts here, https://github.com/MycroftAI/installers"    
+        output = "Follow the plasmoid install guide" \
+                 "at, https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
+                 "If you are running an Ubuntu or Fedora based distribution" \
+                 "You can find the installation scripts" \
+                 "here, https://github.com/MycroftAI/installers"
         assert output in testbot.pop_message()
-        
+
     def test_install_qtapp(self, testbot):
         testbot.push_message('!install_qt_application')
-        output = "The appimage for the qt standalone application project can be found " \
-                 "here, https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"    
+        output = "Appimage for the standalone Qtapplication is available at" \
+                 "https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"
         assert output in testbot.pop_message()
-        
+
     def test_troubleshoot_plasmoid(self, testbot):
         testbot.push_message('!troubleshoot_plasmoid')
         output = "Steps to troubleshoot your plasmoid install" \
                  "* Check if mycroft-core is installed correctly" \
                  "* Open plasmoid settings and check your mycroft path" \
-                 "* Run plasmashell in debug mode and check for error messages" \
+                 "* Run plasmashell in debug mode report error messages" \
                  "* Submit your issue/bug report on the #desktop channel, or" \
-                 "* Create a bug report here, https://bugs.kde.org/describecomponents.cgi?product=plasma-mycroft"
+                 "* Create a bug report at https://bugs.kde.org/" \
+                 "/describecomponents.cgi?product=plasma-mycroft"
         assert output in testbot.pop_message()
-        
+
     def test_picroft_docs(self, testbot):
         testbot.push_message('!picroft_docs')
         output = "The documentation for the picroft project can be found " \
@@ -93,12 +94,12 @@ class TestMycroftBot(object):
         output = "The current list of mycroft skills can be found here, " \
                  "https://github.com/MycroftAI/mycroft-skills"
         assert output in testbot.pop_message()
-        
+
     def test_desktop_clients(self, testbot):
         testbot.push_message('!available_desktop_clients')
         output = "The current list of mycroft desktop clients, " \
-                 "KDE Plasma Desktop: https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
-                 "Other Desktop Environments: https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"    
+                 "KDE: http://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
+                 "Others: https://github.com/AIIX/Mycroft-AI-QtApplication"
         assert output in testbot.pop_message()
 
     def test_wake_word(self, testbot):
@@ -107,7 +108,7 @@ class TestMycroftBot(object):
                  "by using the docs here, " \
                  "https://docs.mycroft.ai/installing.and.running/faq"
         assert output in testbot.pop_message()
-        
+
     def test_hello(self, testbot):
         testbot.push_message('!hello')
         output = "Hello I can answer things related to Mycroft, you can " \

--- a/test_mycroft.py
+++ b/test_mycroft.py
@@ -45,7 +45,31 @@ class TestMycroftBot(object):
                  "here, https://github.com/MycroftAI/enclosure-picroft/wiki" \
                  "/Getting-Started-Guide."
         assert output in testbot.pop_message()
-
+        
+    def test_install_plasmoid(self, testbot):
+        testbot.push_message('!install_kde_plasmoid')
+        output = "The install guide for the KDE plasmoid project can be found " \
+                 "here, https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
+                 "If you are running a Debian/Ubuntu or Fedora based distribution" \
+                 "You can find the installation scripts here, https://github.com/MycroftAI/installers"    
+        assert output in testbot.pop_message()
+        
+    def test_install_qtapp(self, testbot):
+        testbot.push_message('!install_qt_application')
+        output = "The appimage for the qt standalone application project can be found " \
+                 "here, https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"    
+        assert output in testbot.pop_message()
+        
+    def test_troubleshoot_plasmoid(self, testbot):
+        testbot.push_message('!troubleshoot_plasmoid')
+        output = "Steps to troubleshoot your plasmoid install" \
+                 "* Check if mycroft-core is installed correctly" \
+                 "* Open plasmoid settings and check your mycroft path" \
+                 "* Run plasmashell in debug mode and check for error messages" \
+                 "* Submit your issue/bug report on the #desktop channel, or" \
+                 "* Create a bug report here, https://bugs.kde.org/describecomponents.cgi?product=plasma-mycroft"
+        assert output in testbot.pop_message()
+        
     def test_picroft_docs(self, testbot):
         testbot.push_message('!picroft_docs')
         output = "The documentation for the picroft project can be found " \
@@ -68,6 +92,13 @@ class TestMycroftBot(object):
         testbot.push_message('!available_skills')
         output = "The current list of mycroft skills can be found here, " \
                  "https://github.com/MycroftAI/mycroft-skills"
+        assert output in testbot.pop_message()
+        
+    def test_desktop_clients(self, testbot):
+        testbot.push_message('!available_desktop_clients')
+        output = "The current list of mycroft desktop clients, " \
+                 "KDE Plasma Desktop: https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
+                 "Other Desktop Environments: https://github.com/AIIX/Mycroft-Ai-QtApplication/releases"    
         assert output in testbot.pop_message()
 
     def test_wake_word(self, testbot):

--- a/test_mycroft.py
+++ b/test_mycroft.py
@@ -96,7 +96,7 @@ class TestMycroftBot(object):
         assert output in testbot.pop_message()
 
     def test_desktop_clients(self, testbot):
-        testbot.push_message('!available_desktop_clients')
+        testbot.push_message('!desktop_clients')
         output = "The current list of mycroft desktop clients, " \
                  "KDE: http://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
                  "Others: https://github.com/AIIX/Mycroft-AI-QtApplication"

--- a/test_mycroft.py
+++ b/test_mycroft.py
@@ -46,7 +46,7 @@ class TestMycroftBot(object):
         assert output in testbot.pop_message()
 
     def test_install_plasmoid(self, testbot):
-        testbot.push_message('!install_kde_plasmoid')
+        testbot.push_message('!install_plasmoid')
         output = "Follow the plasmoid install guide" \
                  "at, https://cgit.kde.org/plasma-mycroft.git/tree/Readme.md" \
                  "If you are running an Ubuntu or Fedora based distribution" \


### PR DESCRIPTION
## Description:
Adds desktop sections to the bot with basic information about installation of desktop clients, troubleshooting desktop clients and different clients

**Related issue (if applicable):** resolves #<err-mycroft issue number goes here>



## Checklist:
- [x] Build Tests for New Code - https://travis-ci.org/btotharye/err-mycroft
- [] Coveralls % Still 100% - https://coveralls.io/github/btotharye/err-mycroft?branch=master
